### PR TITLE
Fix search not working with uppercase letters

### DIFF
--- a/app/src/main/java/com/steleot/jetpackcompose/playground/compose/SearchScreen.kt
+++ b/app/src/main/java/com/steleot/jetpackcompose/playground/compose/SearchScreen.kt
@@ -172,6 +172,6 @@ class SearchViewModel : ViewModel() {
 
     fun onSearchChange(search: String) {
         _search.value = search
-        _filteredRoutes.value = routes.filter { search in it }
+        _filteredRoutes.value = routes.filter { search.lowercase() in it.lowercase() }
     }
 }


### PR DESCRIPTION
Fixes #2. The problem was where I expected, so it was an easy fix.

I think the `routes` are always in lowercase, i dint't check that,  but we can call `it.lowercase()` just in case.